### PR TITLE
Support Sphinx 5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.6.2,<4"
 "zope.interface" = "^5.2.0"
-Sphinx = ">=3.4.2,<5.0.0"
+Sphinx = ">=3.4.2,<6.0.0"
 importlib-metadata = {version = "^4.8.1", optional = true}
 sphinx-book-theme = {version = "^0.1.7", optional = true}
 

--- a/sphinxcontrib/zopeext/autointerface.py
+++ b/sphinxcontrib/zopeext/autointerface.py
@@ -47,7 +47,7 @@ from typing import Any, Dict, Tuple
 import sphinx.ext.autodoc
 import sphinx.domains.python
 import sphinx.roles
-from sphinx.locale import _
+from sphinx.locale import _, __
 from sphinx.application import Sphinx
 
 import zope.interface.interface
@@ -56,7 +56,6 @@ from sphinx.ext.autodoc import (
     ClassDocumenter,
     ObjectMembers,
     logger,
-    __,
 )
 from sphinx.domains.python import PyXRefRole
 
@@ -210,13 +209,13 @@ class InterfaceAttributeDocumenter(sphinx.ext.autodoc.AttributeDocumenter):
         self.non_data_descriptor = False
         super().add_directive_header(sig)
 
-    def add_content(self, more_content, no_docstring=False):
+    def add_content(self, more_content):
         # Correct behavior of AttributeDocumenter.add_content.
         # Don't run the source analyzer... just get the documentation
         self.analyzer = None
         # Treat attributes as datadescriptors since they have docstrings
         self.non_data_descriptor = False
-        super().add_content(more_content, no_docstring)
+        super().add_content(more_content)
 
 
 class InterfaceMethodDocumenter(sphinx.ext.autodoc.MethodDocumenter):


### PR DESCRIPTION
This resolves https://github.com/sphinx-contrib/zopeext/issues/7.  This project already requires Sphinx >= 3.4.2.  The `no_docstring` parameter to `add_content` was already deprecated in Sphinx 3.4.0, so there is no harm in removing it.  It is completely gone in Sphinx 5.0.0.

The change in import for `__` is just a bit of code cleanliness, since both `_` and `__` are defined in `sphinx.locale`.  The name `__` is only incidentally available from `sphinx.ext.autodoc` because it is imported there.  All of that was already true in Sphinx 3.4.2.

With this change applied, I can successfully build docs for ZODB with Sphinx 5.0.2.